### PR TITLE
Fixes for synapse mutex

### DIFF
--- a/lib/control/ackermann/common.c
+++ b/lib/control/ackermann/common.c
@@ -18,7 +18,7 @@ void ackermann_set_actuators(synapse_msgs_Actuators* msg, double turn_angle, dou
     msg->position[0] = turn_angle;
     msg->velocity[0] = omega_fwd;
 #ifdef CONFIG_BUGGY3_MOTOR_ENB_REQUIRED
-    msg->normalized[0] = -1;
+    msg->normalized[0] = 1;
 #endif
 }
 

--- a/lib/synapse/ethernet/main.c
+++ b/lib/synapse/ethernet/main.c
@@ -87,10 +87,7 @@ static void write_ethernet(TinyFrame* tf, const uint8_t* buf, uint32_t len)
     } while (len);
 }
 
-static TinyFrame g_tf = {
-    .write = write_ethernet,
-    .peer_bit = TF_MASTER,
-};
+static TinyFrame g_tf = { 0 };
 
 static TF_Result genericListener(TinyFrame* tf, TF_Msg* msg)
 {
@@ -137,6 +134,8 @@ static void ethernet_entry_point(void)
     int serv;
     struct sockaddr_in bind_addr;
     static int counter;
+
+    TF_InitStatic(&g_tf, TF_MASTER, write_ethernet);
 
     serv = zsock_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     set_blocking_enabled(serv, true);

--- a/lib/synapse/zbus/syn_pub_sub.c
+++ b/lib/synapse/zbus/syn_pub_sub.c
@@ -128,7 +128,7 @@ int syn_node_add_sub(syn_node_t* node,
     __ASSERT(sub != NULL, "sub is null");
     __ASSERT(msg != NULL, "msg is null");
 
-    syn_sub_init(sub, msg, chan);
+    RC(syn_sub_init(sub, msg, chan), return rc);
     syn_sub_t* tail = node->sub_list_head;
     if (tail == NULL) {
         node->sub_list_head = sub;
@@ -158,7 +158,7 @@ int syn_node_add_pub(syn_node_t* node,
     __ASSERT(msg != NULL, "msg is null");
     __ASSERT(chan != NULL, "chan is null");
 
-    syn_pub_init(pub, msg, chan);
+    RC(syn_pub_init(pub, msg, chan), return rc);
     syn_pub_t* tail = node->pub_list_head;
     if (tail == NULL) {
         node->pub_list_head = pub;

--- a/west.yml
+++ b/west.yml
@@ -19,7 +19,7 @@ manifest:
     - name: zephyr
       remote: cognipilot
       west-commands: scripts/west-commands.yml
-      revision: e82fa68099ab6fd357881eadce1f0c3ffec463b9 # new_dev 10/20/23
+      revision: e82fa68099ab6fd357881eadce1f0c3ffec463b9 # temp_dev 10/20/23
       import:
         - name-allowlist:
           - nanopb
@@ -29,7 +29,7 @@ manifest:
           - ubxlib
     - name: synapse_tinyframe
       remote: cognipilot
-      revision: 8ea7c6ab3c5cc60a28fe7d5553a4d12f3a85bbec # main 8/21/23
+      revision: a566447d677030975d398b23485d778b59c5325e # pr-mutex-fix 10/29/23
       path: modules/lib/synapse_tinyframe
     - name: synapse_protobuf
       remote: cognipilot


### PR DESCRIPTION
Updates synapse tinyframe to use mutex to deal with compile issues on latest zephyr.