### PR TITLE
Update synapse_protobuf for build order.

### DIFF
--- a/lib/synapse/eth_rx/CMakeLists.txt
+++ b/lib/synapse/eth_rx/CMakeLists.txt
@@ -10,3 +10,5 @@ zephyr_library_sources(
   src/main.c
   src/proto/udp_rx.c
   )
+
+add_dependencies(cerebri_synapse_eth_rx synapse_protobuf)

--- a/lib/synapse/eth_tx/CMakeLists.txt
+++ b/lib/synapse/eth_tx/CMakeLists.txt
@@ -10,3 +10,5 @@ zephyr_library_sources(
   src/main.c
   src/proto/udp_tx.c
   )
+
+add_dependencies(cerebri_synapse_eth_tx synapse_protobuf)

--- a/west.yml
+++ b/west.yml
@@ -40,7 +40,7 @@ manifest:
       path: modules/lib/synapse_tinyframe
     - name: synapse_protobuf
       remote: cognipilot
-      revision: a32619cd57bf692893088189e8f5d0c8cec44ecb # main 04/12/24
+      revision: 1c38c6ef5e3a7c147e8d8c1477959b8d4ad3b19e # main 05/28/24
       path: modules/lib/synapse_protobuf
     - name: ubxlib
       remote: cognipilot


### PR DESCRIPTION
Fixes build failures due to nanopb build order of proto files. Closes #141 