### PR TITLE
Fix spelling.

### DIFF
--- a/app/b3rb/src/input_mapping.c
+++ b/app/b3rb/src/input_mapping.c
@@ -46,9 +46,9 @@ void input_request_compute(struct input_request* req, const synapse_msgs_Input* 
 
     if (input->channel[CH_VRA_CW] > 0.5f && !req->lights_on) {
         req->lights_on = true;
-        LOG_INF("requeest lights on");
+        LOG_INF("request lights on");
     } else if (input->channel[CH_VRA_CW] < -0.5f && req->lights_on) {
-        LOG_INF("requeest lights off");
+        LOG_INF("request lights off");
         req->lights_on = false;
     }
 }


### PR DESCRIPTION
![ants](https://github.com/CogniPilot/cerebri/assets/10233412/b75360db-001c-4ad7-8c8d-995bd8077700)
