### PR TITLE
Add DShot DTS update rate and run @ 200Hz by default 

### DIFF
--- a/dts/bindings/cerebri,dshot-actuators.yaml
+++ b/dts/bindings/cerebri,dshot-actuators.yaml
@@ -8,6 +8,13 @@ description: DSHOT actuators parent node
 
 compatible: "cerebri,dshot-actuators"
 
+properties:
+  rate:
+    type: int
+    default: 200
+    description: |
+      Update rate of the dshot signal in Hz
+
 child-binding:
   description: DSHOT actuators node
   properties:


### PR DESCRIPTION
Typical DShot ESC atleast want to have an update above ~ 100Hz.
Solves issues with some DShot ESC's not responding to commands

**Alternative fixes**
Right now this sets a fixed DShot update rate, if actuator would ever go > 400Hz we might want to change the behavior because then we would drop setpoints instead. 