### PR TITLE
app: rdd2: Fix ethernet link down

### DIFF
--- a/app/rdd2/boards/vmu_rt1170_mimxrt1176_cm7.overlay
+++ b/app/rdd2/boards/vmu_rt1170_mimxrt1176_cm7.overlay
@@ -150,6 +150,10 @@
 	/delete-node/ bmp388@76;
 };
 
+&enet1g_phy {
+	master-slave = "auto";
+};
+
 /* GNSS 1 */
 uart0: &lpuart3 {
        status = "okay";


### PR DESCRIPTION
With the latest Zephyr changes, now the ETH PHY needs to specify the master-slave role, according to 100Base-T1. Set to "auto" so minimal configuration is required on the Linux-side. After this patch the RDD2 app has the ZROS-ROS2 link working again.