### PR TITLE
lib: core: Disable auto-enabling of CEREBRI_CORE_COMMON

### DIFF
--- a/lib/core/common/Kconfig
+++ b/lib/core/common/Kconfig
@@ -3,7 +3,6 @@
 menuconfig CEREBRI_CORE_COMMON
   bool "Enable core common"
   select ZROS_PERF
-  default y
   help
      This option enables the core common library
 


### PR DESCRIPTION
As it is not required: All cerebri apps select it, and if we try to build a non-cerebri app (e.g: a Zephyr sample), this will cause build-time issues.