### PR TITLE
Add CRSF and telemetry support

### DIFF
--- a/drivers/sense/rc/CMakeLists.txt
+++ b/drivers/sense/rc/CMakeLists.txt
@@ -11,4 +11,4 @@ zephyr_library_sources(
   main.c
   )
 
-add_dependencies(cerebri_sense_sbus synapse_pb)
+add_dependencies(cerebri_sense_sbus synapse_pb cerebri_core_common)

--- a/drivers/sense/rc/crsf_yaapu.h
+++ b/drivers/sense/rc/crsf_yaapu.h
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026 CogniPilot Foundation
+ * Copyright (c) 2026 NXP Semiconductors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CRSF_YAAPU_H_
+#define CRSF_YAAPU_H_
+
+#include <stdint.h>
+
+#define CRSF_YAAPU_MESSAGES_APPID   0x5000
+#define CRSF_YAAPU_AP_STATUS_APPID  0x5001
+#define CRSF_YAAPU_GPS_STATUS_APPID 0x5002
+#define CRSF_YAAPU_BATTERY_APPID    0x5003
+#define CRSF_YAAPU_HOME_APPID       0x5004
+#define CRSF_YAAPU_VELANDYAW_APPID  0x5005
+#define CRSF_YAAPU_ROLLPITCH_APPID  0x5006
+#define CRSF_YAAPU_PARAMS_APPID     0x5007
+#define CRSF_YAAPU_BATTERY2_APPID   0x5008
+#define CRSF_YAAPU_WAYPOINTS_APPID  0x5009
+#define CRSF_YAAPU_RPM_APPID        0x500A
+#define CRSF_YAAPU_TERRAIN_APPID    0x500B
+#define CRSF_YAAPU_VFR_APPID        0x50F2
+
+// 0x5006: ROLLPITCH
+typedef struct __packed {
+	uint32_t roll_bits: 11;      // [Deg] Range [-180, 180]. Encode: (deg / 0.2) + 900
+	uint32_t pitch_bits: 10;     // [Deg] Range [-90, 90]. Encode: (deg / 0.2) + 450
+	uint32_t range_exp: 1;       // Power of 10 for range
+	uint32_t range_mantissa: 10; // [cm] Rangefinder. Value = mantissa * 10^exp
+} CRSF_YAAPU_ROLLPITCH;
+
+// 0x5005: VELANDYAW
+typedef struct __packed {
+	uint32_t vspeed_exp: 1;       // Power of 10 for VSpeed
+	uint32_t vspeed_mantissa: 7;  // [m/s] Vertical Speed. Value = mantissa * 10^exp
+	uint32_t vspeed_sign: 1;      // 1 = negative VSpeed
+	uint32_t speed_exp: 1;        // Power of 10 for HSpeed/Airspeed
+	uint32_t speed_mantissa: 7;   // [dm/s] Ground/Air speed. Value = mantissa * 10^exp
+	uint32_t yaw_bits: 11;        // [Deg] Heading. Encode: deg / 0.2
+	uint32_t airspeed_enabled: 1; // 1 = Speed field is Airspeed, 0 = Groundspeed
+	uint32_t reserved: 3;         // Unused
+} CRSF_YAAPU_VELANDYAW;
+
+// 0x5001: AP STATUS
+typedef struct __packed {
+	uint32_t flight_mode: 5;    // ArduPilot Flight Mode ID
+	uint32_t simple_mode: 2;    // Simple/SuperSimple flags
+	uint32_t land_complete: 1;  // 1 = Landed
+	uint32_t armed: 1;          // 1 = Armed
+	uint32_t batt_failsafe: 1;  // 1 = Failsafe active
+	uint32_t ekf_failsafe: 2;   // EKF status flags
+	uint32_t failsafe: 1;       // General failsafe
+	uint32_t fence_present: 1;  // 1 = Geofence enabled
+	uint32_t fence_breached: 1; // 1 = Geofence breached
+	uint32_t reserved: 4;       // Unused
+	uint32_t throttle_val: 6;   // [%] Throttle. Encode: percent / 1.58
+	uint32_t throttle_sign: 1;  // 1 = negative throttle (reverse)
+	uint32_t imu_temp: 6;       // [°C] Temperature. Encode: temp_c - 19
+} CRSF_YAAPU_AP_STATUS;
+
+// 0x5002: GPS STATUS
+typedef struct __packed {
+	uint32_t num_sats: 4;      // Sat count
+	uint32_t gps_status_lo: 2; // Fix type low bits (0=No GPS, 2=2D, 3=3D+)
+	uint32_t hdop_exp: 1;      // Power of 10 for HDOP
+	uint32_t hdop_mantissa: 7; // [dm] HDOP. Value = mantissa * 10^exp
+	uint32_t gps_status_hi: 2; // Fix type high bits (DGPS/RTK flags)
+	uint32_t reserved: 6;      // Unused
+	uint32_t alt_exp: 2;       // Power of 10 for Altitude
+	uint32_t alt_mantissa: 7;  // [dm] GPS Altitude. Value = mantissa * 10^exp
+	uint32_t alt_sign: 1;      // 1 = Negative altitude
+} CRSF_YAAPU_GPS_STATUS;
+
+// 0x5003 & 0x5008: BATTERY
+typedef struct __packed {
+	uint32_t voltage: 9;          // [dV] Decivolts (0.1V). Range 0-51.1V
+	uint32_t current_exp: 1;      // Power of 10 for Current
+	uint32_t current_mantissa: 7; // [dA] Deciamps (0.1A). Value = mantissa * 10^exp
+	uint32_t mah: 15;             // [mAh] Consumed capacity
+} CRSF_YAAPU_BATTERY;
+
+// 0x5004: HOME
+typedef struct __packed {
+	uint32_t dist_exp: 2;       // Power of 10 for Distance
+	uint32_t dist_mantissa: 10; // [m] Dist to Home. Value = mantissa * 10^exp
+	uint32_t alt_exp: 2;        // Power of 10 for Altitude
+	uint32_t alt_mantissa: 10;  // [m] Alt relative to Home. Value = mantissa * 10^exp * 0.1
+	uint32_t alt_sign: 1;       // 1 = Negative altitude
+	uint32_t angle: 7;          // [Deg] Direction to home. Encode: deg / 3
+} CRSF_YAAPU_HOME;
+
+// 0x5000: MESSAGES
+typedef struct __packed {
+	uint32_t char_0: 7;    // ASCII char 1
+	uint32_t sev_bit_0: 1; // Severity bit 0 (LSB)
+	uint32_t char_1: 7;    // ASCII char 2
+	uint32_t sev_bit_1: 1; // Severity bit 1
+	uint32_t char_2: 7;    // ASCII char 3
+	uint32_t sev_bit_2: 1; // Severity bit 2 (MSB)
+	uint32_t char_3: 7;    // ASCII char 4
+	uint32_t reserved: 1;  // Unused
+} CRSF_YAAPU_MESSAGES;
+
+// 0x5007: PARAMS
+typedef struct __packed {
+	uint32_t param_value: 24; // Raw parameter value (int)
+	uint32_t param_id: 4;     // 1=FrameType, 4=Batt1Cap, 5=Batt2Cap
+	uint32_t reserved: 4;     // Unused
+} CRSF_YAAPU_PARAMS;
+
+// 0x5009: WAYPOINTS
+typedef struct __packed {
+	uint32_t wp_index: 10;        // Current Waypoint Index
+	uint32_t dist_exp: 2;         // Power of 10 for Distance
+	uint32_t dist_mantissa: 10;   // [m] Distance to WP. Value = mantissa * 10^exp
+	uint32_t xterror_exp: 1;      // Power of 10 for Crosstrack Error
+	uint32_t xterror_mantissa: 4; // [m] Crosstrack Error. Value = mantissa * 10^exp
+	uint32_t xterror_sign: 1;     // 1 = Negative Error
+	uint32_t reserved: 1;         // Unused
+	uint32_t bearing: 3;          // [Deg] Bearing to WP. Encode: deg / 45
+} CRSF_YAAPU_WAYPOINTS;
+
+// 0x500A: RPM
+typedef struct __packed {
+	int16_t rpm1; // [RPM] Sensor 1 (Raw int16)
+	int16_t rpm2; // [RPM] Sensor 2 (Raw int16)
+} CRSF_YAAPU_RPM;
+
+// 0x500B: TERRAIN
+typedef struct __packed {
+	uint32_t height_exp: 2;       // Power of 10 for Height
+	uint32_t height_mantissa: 10; // [m] Height above terrain. Value = mantissa * 10^exp * 0.1
+	uint32_t height_sign: 1;      // 1 = Negative height
+	uint32_t unhealthy_flag: 1;   // 1 = Terrain data unhealthy
+	uint32_t reserved: 18;        // Unused
+} CRSF_YAAPU_TERRAIN;
+
+// 0x50F2: VFR HUD
+typedef struct __packed {
+	uint32_t airspeed_exp: 1;      // Power of 10 for Airspeed
+	uint32_t airspeed_mantissa: 7; // [dm/s] Airspeed. Value = mantissa * 10^exp
+	uint32_t throttle: 7;          // [%] Throttle (0-100)
+	uint32_t baro_exp: 2;          // Power of 10 for Baro Alt
+	uint32_t baro_mantissa: 10;    // [m] Baro Altitude. Value = mantissa * 10^exp * 0.1
+	uint32_t baro_sign: 1;         // 1 = Negative Altitude
+	uint32_t reserved: 4;          // Unused
+} CRSF_YAAPU_VFR;
+
+typedef struct __packed {
+	uint16_t appid;
+	union {
+		uint32_t raw;
+		CRSF_YAAPU_ROLLPITCH roll_pitch;
+		CRSF_YAAPU_VELANDYAW vel_yaw;
+		CRSF_YAAPU_AP_STATUS ap_status;
+		CRSF_YAAPU_GPS_STATUS gps_status;
+		CRSF_YAAPU_BATTERY battery;
+		CRSF_YAAPU_HOME home;
+		CRSF_YAAPU_MESSAGES messages;
+		CRSF_YAAPU_PARAMS params;
+		CRSF_YAAPU_WAYPOINTS waypoints;
+		CRSF_YAAPU_RPM rpm;
+		CRSF_YAAPU_TERRAIN terrain;
+		CRSF_YAAPU_VFR vfr;
+	} data;
+} CRSF_YAAPU_PACKET;
+
+/* Type 0x50 - AP Custom telem */
+/* Subheader 1 byte (SubID) + 1 byte (Severity) = 2 bytes */
+#define CRSF_AP_CUSTOM_TELEM_SINGLE_PACKET_PASSTHROUGH 0xF0 // Sub-ID for Single Packet Passthrough
+#define CRSF_AP_CUSTOM_TELEM_STATUS_TEXT               0xF1 // Sub-ID for Status Text
+#define CRSF_AP_CUSTOM_TELEM_MULTI_PACKET_PASSTHROUGH  0xF2 // Sub-ID for Multi Packet Passthrough
+
+/* Severity */
+#define CRSF_AP_CUSTOM_SEVERITY_EMERGENCY 0 // System is unusable
+#define CRSF_AP_CUSTOM_SEVERITY_ALERT     1 // Action must be taken immediately
+#define CRSF_AP_CUSTOM_SEVERITY_CRITICAL  2 // System is in a critical condition
+#define CRSF_AP_CUSTOM_SEVERITY_ERROR     3 // Generic error condition
+#define CRSF_AP_CUSTOM_SEVERITY_WARNING   4 // Warning that should be noted
+#define CRSF_AP_CUSTOM_SEVERITY_NOTICE    5 // Normal but significant condition
+#define CRSF_AP_CUSTOM_SEVERITY_INFO      6 // Informational message
+#define CRSF_AP_CUSTOM_SEVERITY_DEBUG     7 // Debugging message
+
+#define CRSF_AP_CUSTOM_TEXT_MAX_LEN 50
+struct crsf_ap_custom_status_text {
+	uint8_t sub_id;   // Always set to CRSF_AP_CUSTOM_TELEM_STATUS_TEXT (0xF1)
+	uint8_t severity; // MAVLink Severity (0=Emergency, 6=Info, etc.)
+	char text[CRSF_AP_CUSTOM_TEXT_MAX_LEN]; // Null-terminated string
+} __packed;
+
+struct crsf_ap_custom_single_packet {
+	uint8_t sub_id;
+	CRSF_YAAPU_PACKET packet;
+} __packed;
+
+#define CRSF_AP_CUSTOM_MULTI_PACKET_FRAME_MAX_LEN 9
+struct crsf_ap_custom_multi_packet {
+	uint8_t sub_id;
+	uint8_t size;
+	CRSF_YAAPU_PACKET packets[CRSF_AP_CUSTOM_MULTI_PACKET_FRAME_MAX_LEN];
+} __packed;
+
+#endif /* CRSF_YAAPU_H_ */

--- a/drivers/sense/rc/main.c
+++ b/drivers/sense/rc/main.c
@@ -11,10 +11,60 @@
 
 #include <zros/private/zros_node_struct.h>
 #include <zros/private/zros_pub_struct.h>
+#include <zros/private/zros_sub_struct.h>
 #include <zros/zros_node.h>
 #include <zros/zros_pub.h>
+#include <zros/zros_sub.h>
 
 #include <synapse_topic_list.h>
+
+#if DT_NODE_HAS_COMPAT(DT_ALIAS(rc), tbs_crsf)
+#include "lib/core/common/casadi/common.h"
+#include <cerebri/core/casadi.h>
+#include <zephyr/drivers/input/input_crsf.h>
+#include <zephyr/sys/byteorder.h>
+#include <float.h>
+#include <math.h>
+#include <stdio.h>
+#include "crsf_yaapu.h"
+#define CRSF_TELEMETRY 1
+
+enum crsf_telem {
+	CRSF_ATTITUDE,
+	CRSF_BATTERY,
+	CRSF_FLIGHT_MODE,
+	CRSF_GPS,
+	CRSF_YAAPU_ATTITUDE,
+	CRSF_YAAPU_GPS,
+	CRSF_YAAPU_STATUS_BAT,
+	CRSF_YAAPU_STATUSTEXT,
+};
+
+struct telem_schedule_entry {
+	enum crsf_telem id;    // The ID used in the switch case
+	float weight;          // Higher weight = sent more frequently
+	int64_t min_period_ms; // Minimum time between sends
+
+	// Internal Scheduler State
+	float virtual_finish_time;
+	int64_t last_sent_ms;
+};
+
+// TODO tune this, maybe make a base crsf telem and yaapu telem schedule
+static struct telem_schedule_entry telem_schedule[] = {
+	// ID                           Weight   Min Period (ms)  Notes
+	//{CRSF_ATTITUDE,                 10.0f,   100,             /* 10 Hz */},
+	{CRSF_GPS, 4.0f, 250, /* 4 Hz */},
+	{CRSF_BATTERY, 1.0f, 1000, /* 1 Hz */},
+	{CRSF_FLIGHT_MODE, 1.0f, 1000, /* 1 Hz */},
+	{CRSF_YAAPU_ATTITUDE, 10.0f, 100, /* 10 Hz (Yaapu) */},
+	{CRSF_YAAPU_STATUSTEXT, 10.0f, 1000, /* 1 Hz (Yaapu) */},
+	{CRSF_YAAPU_STATUS_BAT, 2.0f, 500, /* 2 Hz (Yaapu) */},
+};
+
+static const int telem_schedule_count = sizeof(telem_schedule) / sizeof(telem_schedule[0]);
+
+#endif
 
 #define MY_STACK_SIZE 2048
 #define MY_PRIORITY   2
@@ -32,6 +82,15 @@ struct context {
 	k_thread_stack_t *stack_area;
 	struct k_thread thread_data;
 	int last_event;
+#ifdef CRSF_TELEMETRY
+	enum crsf_telem telem_state;
+	synapse_pb_BatteryState battery_state;
+	synapse_pb_Status status;
+	synapse_pb_Odometry odometry_estimator;
+	struct zros_sub sub_battery_state, sub_status, sub_odometry_estimator;
+	bool yaapu_startup;
+	uint32_t yaapu_status_seqno;
+#endif
 };
 
 static struct context g_ctx = {
@@ -43,6 +102,17 @@ static struct context g_ctx = {
 	.stack_area = g_my_stack_area,
 	.thread_data = {},
 	.last_event = 0,
+#ifdef CRSF_TELEMETRY
+	.telem_state = CRSF_GPS,
+	.battery_state = synapse_pb_BatteryState_init_default,
+	.status = synapse_pb_Status_init_default,
+	.odometry_estimator = synapse_pb_Odometry_init_default,
+	.sub_battery_state = {},
+	.sub_status = {},
+	.sub_odometry_estimator = {},
+	.yaapu_startup = 0,
+	.yaapu_status_seqno = 0,
+#endif
 };
 
 static void sense_rc_init(struct context *ctx)
@@ -50,12 +120,24 @@ static void sense_rc_init(struct context *ctx)
 	zros_node_init(&ctx->node, "sense_rc");
 	zros_pub_init(&ctx->pub_input, &ctx->node, &topic_input_rc, &ctx->input);
 	ctx->last_event = 0;
+#ifdef CRSF_TELEMETRY
+	zros_sub_init(&ctx->sub_battery_state, &ctx->node, &topic_battery_state,
+		      &ctx->battery_state, 10);
+	zros_sub_init(&ctx->sub_status, &ctx->node, &topic_status, &ctx->status, 10);
+	zros_sub_init(&ctx->sub_odometry_estimator, &ctx->node, &topic_odometry_estimator,
+		      &ctx->odometry_estimator, 10);
+#endif
 	k_sem_take(&ctx->running, K_FOREVER);
 	LOG_INF("init");
 }
 
 static void sense_rc_fini(struct context *ctx)
 {
+#ifdef CRSF_TELEMETRY
+	zros_sub_fini(&ctx->sub_battery_state);
+	zros_sub_fini(&ctx->sub_status);
+	zros_sub_fini(&ctx->sub_odometry_estimator);
+#endif
 	zros_pub_fini(&ctx->pub_input);
 	zros_node_fini(&ctx->node);
 	k_sem_give(&ctx->running);
@@ -70,9 +152,177 @@ static void sense_rc_run(void *p0, void *p1, void *p2)
 
 	sense_rc_init(ctx);
 
+#ifdef CRSF_TELEMETRY
+	const struct device *dev = DEVICE_DT_GET(DT_ALIAS(rc));
+
+	// Setup Yaapu configuration
+	{
+		struct crsf_ap_custom_multi_packet payload;
+		payload.sub_id = CRSF_AP_CUSTOM_TELEM_MULTI_PACKET_PASSTHROUGH;
+		payload.size = 2;
+		payload.packets[0].appid = CRSF_YAAPU_PARAMS_APPID;
+		payload.packets[0].data.params.param_id = 1; // Frame Type
+		payload.packets[0].data.params.param_value =
+			(uint8_t)('c'); // Copter TODO be more flexible
+		payload.packets[1].appid = CRSF_YAAPU_PARAMS_APPID;
+		payload.packets[1].data.params.param_id = 4;      // Batt 1 Cap
+		payload.packets[1].data.params.param_value = 100; // now we cheat to get percentage
+		input_crsf_send_telemetry(dev, CRSF_TYPE_AP_CUSTOM_TELEM, (uint8_t *)&payload,
+					  2 + payload.size * 6);
+	}
+
+	// Initialize scheduler state (optional, ensures clean start)
+	int64_t now = k_uptime_get();
+	for (int i = 0; i < telem_schedule_count; i++) {
+		telem_schedule[i].last_sent_ms = now - telem_schedule[i].min_period_ms;
+		telem_schedule[i].virtual_finish_time = 0.0f;
+	}
+
+	// Loop runs while the 'running' semaphore is NOT given (timeout ensures periodic run)
+	while (k_sem_take(&ctx->running, K_MSEC(10)) < 0) {
+
+		now = k_uptime_get();
+		struct telem_schedule_entry *best_candidate = NULL;
+		float min_vft = FLT_MAX;
+
+		// WFQ SCHEDULER  Find the eligible item with the smallest Virtual Finish Time
+		for (int i = 0; i < telem_schedule_count; i++) {
+			struct telem_schedule_entry *entry = &telem_schedule[i];
+
+			if ((now - entry->last_sent_ms) < entry->min_period_ms) {
+				continue;
+			}
+
+			if (entry->virtual_finish_time < min_vft) {
+				min_vft = entry->virtual_finish_time;
+				best_candidate = entry;
+			}
+		}
+
+		// If no candidate is ready (all rate-limited), wait for next loop cycle
+		if (!best_candidate) {
+			continue;
+		}
+
+		switch (best_candidate->id) {
+
+		case CRSF_ATTITUDE:
+			break;
+
+		case CRSF_BATTERY: {
+			zros_sub_update(&ctx->sub_battery_state);
+			struct crsf_payload_battery bat_payload;
+			bat_payload.voltage_dV =
+				sys_cpu_to_be16((int16_t)(ctx->battery_state.voltage * 10));
+			bat_payload.current_dA =
+				sys_cpu_to_be16((int16_t)(ctx->battery_state.current * 10));
+			bat_payload.remaining_pct = (int8_t)(ctx->status.fuel_percentage);
+			input_crsf_send_telemetry(dev, CRSF_TYPE_BATTERY, (uint8_t *)&bat_payload,
+						  sizeof(struct crsf_payload_battery));
+		} break;
+
+		case CRSF_FLIGHT_MODE: {
+			zros_sub_update(&ctx->sub_status);
+			input_crsf_send_telemetry(dev, CRSF_TYPE_FLIGHT_MODE,
+						  (uint8_t *)mode_str(ctx->status.mode),
+						  strlen(mode_str(ctx->status.mode)) + 1);
+		} break;
+
+		case CRSF_GPS:
+			// TODO Add GPS logic here
+			break;
+
+		case CRSF_YAAPU_ATTITUDE: {
+			zros_sub_update(&ctx->sub_odometry_estimator);
+			struct crsf_ap_custom_multi_packet payload;
+			payload.sub_id = CRSF_AP_CUSTOM_TELEM_MULTI_PACKET_PASSTHROUGH;
+			payload.size = 2;
+
+			double q[4] = {ctx->odometry_estimator.pose.orientation.w,
+				       ctx->odometry_estimator.pose.orientation.x,
+				       ctx->odometry_estimator.pose.orientation.y,
+				       ctx->odometry_estimator.pose.orientation.z};
+			double yaw, pitch, roll;
+			double rad2deg = 180 / 3.14159;
+			CASADI_FUNC_ARGS(quat_to_eulerB321)
+			args[0] = q;
+			res[0] = &yaw;
+			res[1] = &pitch;
+			res[2] = &roll;
+			CASADI_FUNC_CALL(quat_to_eulerB321)
+
+			payload.packets[0].appid = CRSF_YAAPU_ROLLPITCH_APPID;
+			payload.packets[0].data.roll_pitch.roll_bits =
+				((rad2deg * roll) / 0.2) + 900;
+			payload.packets[0].data.roll_pitch.pitch_bits =
+				((rad2deg * pitch) / 0.2) + 450;
+			payload.packets[1].appid = CRSF_YAAPU_VELANDYAW_APPID;
+			payload.packets[1].data.vel_yaw.yaw_bits = (rad2deg * yaw) / 0.2;
+
+			input_crsf_send_telemetry(dev, CRSF_TYPE_AP_CUSTOM_TELEM,
+						  (uint8_t *)&payload, 2 + payload.size * 6);
+		} break;
+
+		case CRSF_YAAPU_STATUSTEXT: {
+			zros_sub_update(&ctx->sub_status);
+			if (ctx->status.request_seq > ctx->yaapu_status_seqno) {
+				ctx->yaapu_status_seqno = ctx->status.request_seq;
+				struct crsf_ap_custom_status_text payload;
+				payload.sub_id = CRSF_AP_CUSTOM_TELEM_STATUS_TEXT;
+				payload.severity = CRSF_AP_CUSTOM_SEVERITY_INFO;
+				snprintf(payload.text, sizeof(payload.text), "%.49s",
+					 ctx->status.status_message);
+				input_crsf_send_telemetry(dev, CRSF_TYPE_AP_CUSTOM_TELEM,
+							  (uint8_t *)&payload,
+							  strlen(payload.text) + 3);
+			}
+		} break;
+
+		case CRSF_YAAPU_STATUS_BAT: {
+			zros_sub_update(&ctx->sub_status);
+			zros_sub_update(&ctx->sub_battery_state);
+			struct crsf_ap_custom_multi_packet payload;
+			payload.sub_id = CRSF_AP_CUSTOM_TELEM_MULTI_PACKET_PASSTHROUGH;
+			payload.size = 2;
+			payload.packets[0].appid = CRSF_YAAPU_AP_STATUS_APPID;
+			payload.packets[0].data.raw = 0x0;
+			payload.packets[0].data.ap_status.armed =
+				ctx->status.arming == synapse_pb_Status_Arming_ARMING_ARMED;
+			// TODO other status
+			payload.packets[1].appid = CRSF_YAAPU_BATTERY_APPID;
+			payload.packets[1].data.raw = 0x0;
+			payload.packets[1].data.battery.voltage = (ctx->battery_state.voltage * 10);
+			if (ctx->battery_state.current <= 12.7) {
+				payload.packets[1].data.battery.current_exp = 0;
+				payload.packets[1].data.battery.current_mantissa =
+					lroundl(ctx->battery_state.current * 10);
+			} else if (ctx->battery_state.current <= 127) {
+				payload.packets[1].data.battery.current_exp = 1;
+				payload.packets[1].data.battery.current_mantissa =
+					lroundl(ctx->battery_state.current);
+			} else {
+				payload.packets[1].data.battery.current_exp = 1;
+				payload.packets[1].data.battery.current_mantissa = 127; // Max value
+			}
+			payload.packets[1].data.battery.mah =
+				100 - ctx->status.fuel_percentage; // Cheat to get percentage
+			input_crsf_send_telemetry(dev, CRSF_TYPE_AP_CUSTOM_TELEM,
+						  (uint8_t *)&payload, 2 + payload.size * 6);
+		} break;
+
+		default:
+			break;
+		}
+
+		best_candidate->last_sent_ms = now;
+		best_candidate->virtual_finish_time += (1.0f / best_candidate->weight);
+	}
+
+#else
 	// wait for stop request
 	while (k_sem_take(&ctx->running, K_MSEC(1000)) < 0)
 		;
+#endif
 
 	sense_rc_fini(ctx);
 }


### PR DESCRIPTION
Basic CRSF support and telemetry 

Todo:

- Make telemetry update dynamic based on transmitter config (we can parse this from link statistics)
- Implement GNSS telemetry
~- Implement attitude telemetry~
- Log link status to zros somehow.

You config needs to add the following for CRC and DMA
```
CONFIG_CRC=y
CONFIG_UART_ASYNC_API=y
```

dts example change compatible to crsf

```
&lpuart8 {
	status = "okay";
	pinctrl-0 = <&pinmux_lpuart8>;
	pinctrl-1 = <&pinmux_lpuart8_sleep>;
	pinctrl-names = "default", "sleep";
	current-speed = <420000>;

	sbus0: sbus {
		compatible = "tbs,crsf";
```